### PR TITLE
Disable std for embedded use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 //! Provides access to the [CODATA recommended 2018 values for physical constants][codata].
 //!
 //! # Examples


### PR DESCRIPTION
There isn't anything in the library that needs `std`, so by disabling it the crate can be used in embedded environments.